### PR TITLE
fix: Handle global array/struct variable paths in debug.c generation

### DIFF
--- a/ProjectController.py
+++ b/ProjectController.py
@@ -94,7 +94,15 @@ class ProjectController:
                             parts = [config_FB] + parts[2:]
                             attrs["C_path"] = ".".join(parts)
                         else:
-                            attrs["C_path"] = "__".join(parts[1:])
+                            # Check if this is a global array/struct variable at CONFIG level
+                            # Pattern: CONFIG0.VARNAME.value.table[x] or CONFIG0.VARNAME.value.fieldname
+                            # These should become: CONFIG0__VARNAME.value.table[x] or CONFIG0__VARNAME.value.fieldname
+                            if parts[0].startswith("CONFIG") and parts[2].startswith("value"):
+                                # Global array or struct access - keep CONFIG prefix
+                                attrs["C_path"] = parts[0] + "__" + parts[1] + "." + parts[2]
+                            else:
+                                # For resource-level variables (RES0.INSTANCE.xxx)
+                                attrs["C_path"] = "__".join(parts[1:])
                     else:
                         attrs["C_path"] = "__".join(parts)
                         if attrs["vartype"] == "FB":


### PR DESCRIPTION
Fix incorrect C path generation for global variables with array or struct access patterns. Previously, paths like CONFIG0.GLOBALVAR.value.table[0] were incorrectly converted to GLOBALVAR__value.table[0], causing compilation errors because the variable is actually declared as CONFIG0__GLOBALVAR.

The fix now correctly handles:
- Global ARRAY variables (e.g., ARRAY [1..10] OF DINT)
- Global Function Block instances (e.g., TON, PID)
- Global ARRAY of Function Blocks (e.g., ARRAY [1..2] OF TON)

For paths starting with CONFIG and containing .value. access patterns, the path is now correctly constructed as CONFIG0__VARNAME.value.xxx